### PR TITLE
Add simple CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build game (no ISO)
+
+on: push
+
+env:
+  PSn00bSDK_REPO: "https://github.com/spicyjpeg/PSn00bSDK"
+  PSn00bSDK_VERSION: "0.21"
+
+jobs:
+  build:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare PSn00bSDK
+        run: |
+          mkdir ~/.sdk
+          cd ~/.sdk
+
+          wget ${PSn00bSDK_REPO}/releases/download/v${PSn00bSDK_VERSION}/PSn00bSDK-${PSn00bSDK_VERSION}-Linux.zip
+          unzip PSn00bSDK-${PSn00bSDK_VERSION}-Linux.zip
+          rm PSn00bSDK-${PSn00bSDK_VERSION}-Linux.zip
+
+          cd -
+      - name: Build target horror
+        run: |
+          export PSN00BSDK_INSTALL_DIR=~/.sdk/PSn00bSDK-${PSn00bSDK_VERSION}-Linux
+          ./build.sh horror

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+rm -rf build
+mkdir -p build
+
+cmake -Bbuild \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_TOOLCHAIN_FILE=${PSN00BSDK_INSTALL_DIR}/lib/libpsn00b/cmake/sdk.cmake \
+    -DPSN00BSDK_TC="" \
+    -DPSN00BSDK_TARGET="mipsel-none-elf" \
+    .
+
+exec make ${1:-all} -C build


### PR DESCRIPTION
Added GitHub Actions CI to the project. It will only compile the target `horror`, this won't create the ISO because of the missing license file. See https://github.com/thetredev/BWHorror/actions/runs/3632400677 for the results. 